### PR TITLE
fix: remove delay when it comes to swiping to the prev/next page

### DIFF
--- a/src/components/pinch-pan-layer/PinchPanLayer.tsx
+++ b/src/components/pinch-pan-layer/PinchPanLayer.tsx
@@ -72,7 +72,7 @@ export default function PinchPanLayer({
   )
 
   const [isOverscrolling, setIsOverscrolling] = useState(false)
-  const [isEligibleForOverscroll, setIsEligibleForOverscroll] = useState(false)
+  const [isEligibleForOverscroll, setIsEligibleForOverscroll] = useState(true)
   function checkIfOverscroll(panDelta: Point) {
     if (!overscroll) {
       return false


### PR DESCRIPTION
**Bug:** Swiping to the left or right to navigate won't work at first. You need to swipe again.

**Cause:** "is eligible for overscroll" flag is set to false by default and it's only set to true if a pan happened. This is why you need to touch the screen once for the swiping to work